### PR TITLE
A few refinements: verbose flag, total param count display, a bit of output progress, and remove MoE params from the config

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,6 +45,7 @@ if __name__ == "__main__":
     del mc["num_local_experts"]
     del mc["router_aux_loss_coef"]
     del mc["router_jitter_noise"]
+    del mc["output_router_logits"]
     mc["model_type"] = "mistral"
     mc["architectures"][0] = "MistralForCausalLM"
     mistral_config = MistralConfig(**mc)

--- a/main.py
+++ b/main.py
@@ -5,12 +5,25 @@ import torch
 import argparse
 os.environ["CUDA_VISIBLE_DEVICES"] = '-1'
 
-
+def count_parameters(model):
+    from prettytable import PrettyTable
+    table = PrettyTable(["Modules", "Parameters"])
+    total_params = 0
+    for name, parameter in model.named_parameters():
+        if not parameter.requires_grad:
+            continue
+        params = parameter.numel()
+        table.add_row([name, params])
+        total_params += params
+    print(table)
+    print(f"Total Trainable Params: {total_params}")
+    return total_params
 
 def parse_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument('--model_id', default="/workspace/text-generation-webui2/models/mistralai_Mixtral-8x7B-Instruct-v0.1")
     parser.add_argument('--target_dir', default="./experts")
+    parser.add_argument('--verbose', action='store_true')
     parser.add_argument('--load_in_8bit', action='store_true')
     return parser.parse_args()
 
@@ -19,18 +32,26 @@ if __name__ == "__main__":
     model_id = args.model_id
     target_dir = args.target_dir
     load_in_8bit = args.load_in_8bit
+    verbose = args.verbose
     configuration = AutoConfig.from_pretrained(model_id)
     if load_in_8bit:
         print("loading in 8bit")
         model = AutoModelForCausalLM.from_pretrained(model_id, device_map="cpu", trust_remote_code=False,load_in_8bit=True)
     else:
         print("Not loading 8bit")
-        model = AutoModelForCausalLM.from_pretrained(model_id, device_map="cpu", trust_remote_code=False)
-    mistral_config = MistralConfig(**dict(configuration.to_dict()))
-    mistral_config.architectures = ['MistralForCausalLM']
+        model = AutoModelForCausalLM.from_pretrained(model_id, device_map="cpu", low_cpu_mem_usage=True, trust_remote_code=False, torch_dtype=torch.bfloat16)
+    mc = configuration.to_dict()
+    del mc["num_experts_per_tok"]
+    del mc["num_local_experts"]
+    del mc["router_aux_loss_coef"]
+    del mc["router_jitter_noise"]
+    mc["model_type"] = "mistral"
+    mc["architectures"][0] = "MistralForCausalLM"
+    mistral_config = MistralConfig(**mc)
     if not os.path.exists(target_dir):
         os.mkdir(target_dir)
     for expert_ind in range(configuration.num_local_experts):
+        print(f"Loading model #{expert_ind}")
         mistral_model = MistralForCausalLM(mistral_config)
         mistral_model.lm_head = model.lm_head
         mistral_model.model.embed_tokens = model.model.embed_tokens
@@ -52,7 +73,11 @@ if __name__ == "__main__":
                 layer_ind].post_attention_layernorm
         for param in mistral_model.parameters():
             param.data = param.data.to(torch.bfloat16)
+        if verbose:
+            count_parameters(mistral_model)
+        print(f"Saving extracted model #{expert_ind}...", end="", flush=True)
         mistral_model.save_pretrained(os.path.join(target_dir, "mistral_expert_" + str(expert_ind)))
+        print(" done.", flush=True)
         try:
             tokenizer = AutoTokenizer.from_pretrained(model_id)
             tokenizer.save_pretrained(os.path.join(target_dir, "mistral_expert_" + str(expert_ind)))


### PR DESCRIPTION
I added a few things to improve usability:

1. Some information to the output so users know it's still running.
2. A  --verbose flag which shows the total parameter count for the new model. (Requires PrettyTable lib)
3. Explicitly pass low_cpu_mem_usage=True
4. Delete a few of the MoE only parameters from the config dictionary.
